### PR TITLE
Fix: react-query-swagger 에서 제공하는 방식으로 코드 수정 및 api 변경으로 인한 수정

### DIFF
--- a/src/api/axios-client.ts
+++ b/src/api/axios-client.ts
@@ -9,12 +9,7 @@
 // ReSharper disable InconsistentNaming
 
 import axios, { AxiosError } from 'axios';
-import type {
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse,
-  CancelToken,
-} from 'axios';
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
 
 //-----ClientClass--Client---
 //----------------------
@@ -27,307 +22,912 @@ import type {
 /* eslint-disable */
 // ReSharper disable InconsistentNaming
 
+
 export class Client {
-  private instance: AxiosInstance;
-  private baseUrl: string;
-  protected jsonParseReviver: ((key: string, value: any) => any) | undefined =
-    undefined;
+    private instance: AxiosInstance;
+    private baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
 
-  constructor(baseUrl?: string, instance?: AxiosInstance) {
-    this.instance = instance ? instance : axios.create();
+    constructor(baseUrl?: string, instance?: AxiosInstance) {
 
-    this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : '';
+        this.instance = instance ? instance : axios.create();
 
-    axios.interceptors.request.use((req) => {
-      const access_token = localStorage.getItem('access_token');
-      req.headers.Authorization = access_token ? `Bearer ${access_token}` : '';
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "";
 
-      return req;
-    });
-  }
-
-  /**
-   * @return Default Response
-   */
-  anonymous(cancelToken?: CancelToken | undefined): Promise<void> {
-    let url_ = this.baseUrl + '/';
-    url_ = url_.replace(/[?&]$/, '');
-    const access_token = localStorage.getItem('access_token');
-
-    let options_: AxiosRequestConfig = {
-      method: 'GET',
-      url: url_,
-      headers: {
-        Authorization: access_token ? `Bearer ${access_token}` : '',
-      },
-      cancelToken,
-    };
-
-    return this.instance
-      .request(options_)
-      .catch((_error: any) => {
-        if (isAxiosError(_error) && _error.response) {
-          return _error.response;
-        } else {
-          throw _error;
-        }
-      })
-      .then((_response: AxiosResponse) => {
-        return this.processAnonymous(_response);
-      });
-  }
-
-  protected processAnonymous(response: AxiosResponse): Promise<void> {
-    const status = response.status;
-    let _headers: any = {};
-    if (response.headers && typeof response.headers === 'object') {
-      for (let k in response.headers) {
-        if (response.headers.hasOwnProperty(k)) {
-          _headers[k] = response.headers[k];
-        }
-      }
     }
-    if (status === 200) {
-      const _responseText = response.data;
-      return Promise.resolve<void>(null as any);
-    } else if (status !== 200 && status !== 204) {
-      const _responseText = response.data;
-      return throwException(
-        'An unexpected server error occurred.',
-        status,
-        _responseText,
-        _headers,
-      );
+
+    /**
+     * @return Default Response
+     */
+    anonymous(  cancelToken?: CancelToken | undefined): Promise<void> {
+        let url_ = this.baseUrl + "/";
+          url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAnonymous(_response);
+        });
     }
-    return Promise.resolve<void>(null as any);
-  }
 
-  /**
-   * @return Default Response
-   */
-  me(cancelToken?: CancelToken | undefined): Promise<void> {
-    let url_ = this.baseUrl + '/auth/me';
-    url_ = url_.replace(/[?&]$/, '');
-    const access_token = localStorage.getItem('access_token');
-
-    let options_: AxiosRequestConfig = {
-      method: 'GET',
-      url: url_,
-      headers: {
-        Authorization: access_token ? `Bearer ${access_token}` : '',
-      },
-      cancelToken,
-    };
-
-    return this.instance
-      .request(options_)
-      .catch((_error: any) => {
-        if (isAxiosError(_error) && _error.response) {
-          return _error.response;
-        } else {
-          throw _error;
+    protected processAnonymous(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
         }
-      })
-      .then((_response: AxiosResponse) => {
-        return this.processMe(_response);
-      });
-  }
+        if (status === 200) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
 
-  protected processMe(response: AxiosResponse): Promise<void> {
-    const status = response.status;
-    let _headers: any = {};
-    if (response.headers && typeof response.headers === 'object') {
-      for (let k in response.headers) {
-        if (response.headers.hasOwnProperty(k)) {
-          _headers[k] = response.headers[k];
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
-      }
+        return Promise.resolve<void>(null as any);
     }
-    if (status === 200) {
-      const _responseText = response.data;
-      return Promise.resolve<void>(_responseText as any);
-    } else if (status !== 200 && status !== 204) {
-      const _responseText = response.data;
-      return throwException(
-        'An unexpected server error occurred.',
-        status,
-        _responseText,
-        _headers,
-      );
+
+    /**
+     * @return Default Response
+     */
+    kakao(  cancelToken?: CancelToken | undefined): Promise<void> {
+        let url_ = this.baseUrl + "/auth/kakao";
+          url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processKakao(_response);
+        });
     }
-    return Promise.resolve<void>(null as any);
-  }
 
-  /**
-   * @return Default Response
-   */
-  kakao(cancelToken?: CancelToken | undefined): Promise<void> {
-    let url_ = this.baseUrl + '/auth/kakao';
-    url_ = url_.replace(/[?&]$/, '');
-    const access_token = localStorage.getItem('access_token');
-
-    let options_: AxiosRequestConfig = {
-      method: 'GET',
-      url: url_,
-      headers: {
-        Authorization: access_token ? `Bearer ${access_token}` : '',
-      },
-      cancelToken,
-    };
-
-    return this.instance
-      .request(options_)
-      .catch((_error: any) => {
-        if (isAxiosError(_error) && _error.response) {
-          return _error.response;
-        } else {
-          throw _error;
+    protected processKakao(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
         }
-      })
-      .then((_response: AxiosResponse) => {
-        return this.processKakao(_response);
-      });
-  }
+        if (status === 200) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
 
-  protected processKakao(response: AxiosResponse): Promise<void> {
-    const status = response.status;
-    let _headers: any = {};
-    if (response.headers && typeof response.headers === 'object') {
-      for (let k in response.headers) {
-        if (response.headers.hasOwnProperty(k)) {
-          _headers[k] = response.headers[k];
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
-      }
+        return Promise.resolve<void>(null as any);
     }
-    if (status === 200) {
-      const _responseText = response.data;
-      return Promise.resolve<void>(null as any);
-    } else if (status !== 200 && status !== 204) {
-      const _responseText = response.data;
-      return throwException(
-        'An unexpected server error occurred.',
-        status,
-        _responseText,
-        _headers,
-      );
+
+    /**
+     * @return Default Response
+     * @deprecated
+     */
+    callback(code: string , cancelToken?: CancelToken | undefined): Promise<void> {
+        let url_ = this.baseUrl + "/auth/kakao/callback?";
+          if (code === undefined || code === null)
+            throw new Error("The parameter 'code' must be defined and cannot be null.");
+          else
+            url_ += "code=" + encodeURIComponent("" + code) + "&";
+          url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processCallback(_response);
+        });
     }
-    return Promise.resolve<void>(null as any);
-  }
 
-  /**
-   * @return Default Response
-   * @deprecated
-   */
-  callback(code: string, cancelToken?: CancelToken | undefined): Promise<void> {
-    let url_ = this.baseUrl + '/auth/kakao/callback?';
-    if (code === undefined || code === null)
-      throw new Error(
-        "The parameter 'code' must be defined and cannot be null.",
-      );
-    else url_ += 'code=' + encodeURIComponent('' + code) + '&';
-    url_ = url_.replace(/[?&]$/, '');
-    const access_token = localStorage.getItem('access_token');
-
-    let options_: AxiosRequestConfig = {
-      method: 'GET',
-      url: url_,
-      headers: {
-        Authorization: access_token ? `Bearer ${access_token}` : '',
-      },
-      cancelToken,
-    };
-
-    return this.instance
-      .request(options_)
-      .catch((_error: any) => {
-        if (isAxiosError(_error) && _error.response) {
-          return _error.response;
-        } else {
-          throw _error;
+    protected processCallback(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
         }
-      })
-      .then((_response: AxiosResponse) => {
-        return this.processCallback(_response);
-      });
-  }
+        if (status === 200) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
 
-  protected processCallback(response: AxiosResponse): Promise<void> {
-    const status = response.status;
-    let _headers: any = {};
-    if (response.headers && typeof response.headers === 'object') {
-      for (let k in response.headers) {
-        if (response.headers.hasOwnProperty(k)) {
-          _headers[k] = response.headers[k];
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
-      }
+        return Promise.resolve<void>(null as any);
     }
-    if (status === 200) {
-      const _responseText = response.data;
-      return Promise.resolve<void>(null as any);
-    } else if (status !== 200 && status !== 204) {
-      const _responseText = response.data;
-      return throwException(
-        'An unexpected server error occurred.',
-        status,
-        _responseText,
-        _headers,
-      );
+
+    /**
+     * @param offset (optional) number
+     * @param limit (optional) number
+     * @param search (optional) 검색어
+     * @return Default Response
+     */
+    teamsAll(offset: string | null | undefined, limit: string | null | undefined, search: string | null | undefined , cancelToken?: CancelToken | undefined): Promise<Anonymous[]> {
+        let url_ = this.baseUrl + "/teams?";
+        if (offset !== undefined && offset !== null)
+            url_ += "offset=" + encodeURIComponent("" + offset) + "&";
+        if (limit !== undefined && limit !== null)
+            url_ += "limit=" + encodeURIComponent("" + limit) + "&";
+        if (search !== undefined && search !== null)
+            url_ += "search=" + encodeURIComponent("" + search) + "&";
+          url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processTeamsAll(_response);
+        });
     }
-    return Promise.resolve<void>(null as any);
-  }
+
+    protected processTeamsAll(response: AxiosResponse): Promise<Anonymous[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(Anonymous.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return Promise.resolve<Anonymous[]>(result200);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<Anonymous[]>(null as any);
+    }
+
+    /**
+     * @param body (optional) 
+     * @return Default Response
+     */
+    teams(body: Body | null | undefined , cancelToken?: CancelToken | undefined): Promise<Anonymous2> {
+        let url_ = this.baseUrl + "/teams";
+          url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processTeams(_response);
+        });
+    }
+
+    protected processTeams(response: AxiosResponse): Promise<Anonymous2> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = Anonymous2.fromJS(resultData200);
+            return Promise.resolve<Anonymous2>(result200);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<Anonymous2>(null as any);
+    }
+
+    /**
+     * @return Default Response
+     */
+    meGET(  cancelToken?: CancelToken | undefined): Promise<Anonymous3> {
+        let url_ = this.baseUrl + "/users/me";
+          url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMeGET(_response);
+        });
+    }
+
+    protected processMeGET(response: AxiosResponse): Promise<Anonymous3> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = Anonymous3.fromJS(resultData200);
+            return Promise.resolve<Anonymous3>(result200);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<Anonymous3>(null as any);
+    }
+
+    /**
+     * @param body (optional) 
+     * @return Default Response
+     */
+    mePUT(body: Body2 | null | undefined , cancelToken?: CancelToken | undefined): Promise<Anonymous4> {
+        let url_ = this.baseUrl + "/users/me";
+          url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMePUT(_response);
+        });
+    }
+
+    protected processMePUT(response: AxiosResponse): Promise<Anonymous4> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (let k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = Anonymous4.fromJS(resultData200);
+            return Promise.resolve<Anonymous4>(result200);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<Anonymous4>(null as any);
+    }
 }
 
 //-----/ClientClass----
 
 export * as Query from './axios-client/Query';
 
-//-----Types.File-----
 
+
+//-----Types.File-----
+export class Body implements IBody {
+    name!: string;
+    image?: string | undefined;
+    introduction?: string | undefined;
+    local?: string | undefined;
+
+    constructor(data?: IBody) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.name = _data["name"];
+            this.image = _data["image"];
+            this.introduction = _data["introduction"];
+            this.local = _data["local"];
+        }
+    }
+
+    static fromJS(data: any): Body {
+        data = typeof data === 'object' ? data : {};
+        let result = new Body();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["name"] = this.name;
+        data["image"] = this.image;
+        data["introduction"] = this.introduction;
+        data["local"] = this.local;
+        return data;
+    }
+}
+
+export interface IBody {
+    name: string;
+    image?: string | undefined;
+    introduction?: string | undefined;
+    local?: string | undefined;
+}
+
+export class Body2 implements IBody2 {
+    position?: string | undefined;
+    height?: number | undefined;
+    weight?: number | undefined;
+
+    constructor(data?: IBody2) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.position = _data["position"];
+            this.height = _data["height"];
+            this.weight = _data["weight"];
+        }
+    }
+
+    static fromJS(data: any): Body2 {
+        data = typeof data === 'object' ? data : {};
+        let result = new Body2();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["position"] = this.position;
+        data["height"] = this.height;
+        data["weight"] = this.weight;
+        return data;
+    }
+}
+
+export interface IBody2 {
+    position?: string | undefined;
+    height?: number | undefined;
+    weight?: number | undefined;
+}
+
+export class Anonymous implements IAnonymous {
+    id!: string;
+    teamName!: string;
+    teamImage!: string;
+    leaderName!: string;
+    leaderImage!: string;
+    local!: string;
+    introduction!: string;
+    peopleCount!: number;
+
+    constructor(data?: IAnonymous) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.teamName = _data["teamName"];
+            this.teamImage = _data["teamImage"];
+            this.leaderName = _data["leaderName"];
+            this.leaderImage = _data["leaderImage"];
+            this.local = _data["local"];
+            this.introduction = _data["introduction"];
+            this.peopleCount = _data["peopleCount"];
+        }
+    }
+
+    static fromJS(data: any): Anonymous {
+        data = typeof data === 'object' ? data : {};
+        let result = new Anonymous();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["teamName"] = this.teamName;
+        data["teamImage"] = this.teamImage;
+        data["leaderName"] = this.leaderName;
+        data["leaderImage"] = this.leaderImage;
+        data["local"] = this.local;
+        data["introduction"] = this.introduction;
+        data["peopleCount"] = this.peopleCount;
+        return data;
+    }
+}
+
+export interface IAnonymous {
+    id: string;
+    teamName: string;
+    teamImage: string;
+    leaderName: string;
+    leaderImage: string;
+    local: string;
+    introduction: string;
+    peopleCount: number;
+}
+
+export class Anonymous2 implements IAnonymous2 {
+    id!: string;
+    teamName!: string;
+    teamImage!: string;
+    leaderName!: string;
+    leaderImage!: string;
+    local!: string;
+    introduction!: string;
+    peopleCount!: number;
+
+    constructor(data?: IAnonymous2) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.teamName = _data["teamName"];
+            this.teamImage = _data["teamImage"];
+            this.leaderName = _data["leaderName"];
+            this.leaderImage = _data["leaderImage"];
+            this.local = _data["local"];
+            this.introduction = _data["introduction"];
+            this.peopleCount = _data["peopleCount"];
+        }
+    }
+
+    static fromJS(data: any): Anonymous2 {
+        data = typeof data === 'object' ? data : {};
+        let result = new Anonymous2();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["teamName"] = this.teamName;
+        data["teamImage"] = this.teamImage;
+        data["leaderName"] = this.leaderName;
+        data["leaderImage"] = this.leaderImage;
+        data["local"] = this.local;
+        data["introduction"] = this.introduction;
+        data["peopleCount"] = this.peopleCount;
+        return data;
+    }
+}
+
+export interface IAnonymous2 {
+    id: string;
+    teamName: string;
+    teamImage: string;
+    leaderName: string;
+    leaderImage: string;
+    local: string;
+    introduction: string;
+    peopleCount: number;
+}
+
+export class Anonymous3 implements IAnonymous3 {
+    id!: string;
+    name!: string;
+    email!: string;
+    emailVerified!: Date;
+    image!: string;
+    introduction!: string;
+    position!: string;
+    height!: number;
+    weight!: number;
+    team!: Team;
+    createdAt!: Date;
+    updatedAt!: Date;
+
+    constructor(data?: IAnonymous3) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.team = new Team();
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.email = _data["email"];
+            this.emailVerified = _data["emailVerified"] ? new Date(_data["emailVerified"].toString()) : <any>undefined;
+            this.image = _data["image"];
+            this.introduction = _data["introduction"];
+            this.position = _data["position"];
+            this.height = _data["height"];
+            this.weight = _data["weight"];
+            this.team = _data["team"] ? Team.fromJS(_data["team"]) : new Team();
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.updatedAt = _data["updatedAt"] ? new Date(_data["updatedAt"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): Anonymous3 {
+        data = typeof data === 'object' ? data : {};
+        let result = new Anonymous3();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["email"] = this.email;
+        data["emailVerified"] = this.emailVerified ? this.emailVerified.toISOString() : <any>undefined;
+        data["image"] = this.image;
+        data["introduction"] = this.introduction;
+        data["position"] = this.position;
+        data["height"] = this.height;
+        data["weight"] = this.weight;
+        data["team"] = this.team ? this.team.toJSON() : <any>undefined;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["updatedAt"] = this.updatedAt ? this.updatedAt.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IAnonymous3 {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified: Date;
+    image: string;
+    introduction: string;
+    position: string;
+    height: number;
+    weight: number;
+    team: Team;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export class Anonymous4 implements IAnonymous4 {
+    id!: string;
+    name!: string;
+    email!: string;
+    emailVerified!: Date;
+    image!: string;
+    introduction!: string;
+    position!: string;
+    height!: number;
+    weight!: number;
+    team!: Team2;
+    createdAt!: Date;
+    updatedAt!: Date;
+
+    constructor(data?: IAnonymous4) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.team = new Team2();
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.email = _data["email"];
+            this.emailVerified = _data["emailVerified"] ? new Date(_data["emailVerified"].toString()) : <any>undefined;
+            this.image = _data["image"];
+            this.introduction = _data["introduction"];
+            this.position = _data["position"];
+            this.height = _data["height"];
+            this.weight = _data["weight"];
+            this.team = _data["team"] ? Team2.fromJS(_data["team"]) : new Team2();
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.updatedAt = _data["updatedAt"] ? new Date(_data["updatedAt"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): Anonymous4 {
+        data = typeof data === 'object' ? data : {};
+        let result = new Anonymous4();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["email"] = this.email;
+        data["emailVerified"] = this.emailVerified ? this.emailVerified.toISOString() : <any>undefined;
+        data["image"] = this.image;
+        data["introduction"] = this.introduction;
+        data["position"] = this.position;
+        data["height"] = this.height;
+        data["weight"] = this.weight;
+        data["team"] = this.team ? this.team.toJSON() : <any>undefined;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["updatedAt"] = this.updatedAt ? this.updatedAt.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IAnonymous4 {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified: Date;
+    image: string;
+    introduction: string;
+    position: string;
+    height: number;
+    weight: number;
+    team: Team2;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export class Team implements ITeam {
+    id!: string;
+    name!: string;
+    image!: string;
+
+    constructor(data?: ITeam) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.image = _data["image"];
+        }
+    }
+
+    static fromJS(data: any): Team {
+        data = typeof data === 'object' ? data : {};
+        let result = new Team();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["image"] = this.image;
+        return data;
+    }
+}
+
+export interface ITeam {
+    id: string;
+    name: string;
+    image: string;
+}
+
+export class Team2 implements ITeam2 {
+    id!: string;
+    name!: string;
+    image!: string;
+
+    constructor(data?: ITeam2) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.image = _data["image"];
+        }
+    }
+
+    static fromJS(data: any): Team2 {
+        data = typeof data === 'object' ? data : {};
+        let result = new Team2();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["image"] = this.image;
+        return data;
+    }
+}
+
+export interface ITeam2 {
+    id: string;
+    name: string;
+    image: string;
+}
 //-----/CustomTypes.File-----
 
 export class ApiException extends Error {
-  message: string;
-  status: number;
-  response: string;
-  headers: { [key: string]: any };
-  result: any;
+    message: string;
+    status: number;
+    response: string;
+    headers: { [key: string]: any; };
+    result: any;
 
-  constructor(
-    message: string,
-    status: number,
-    response: string,
-    headers: { [key: string]: any },
-    result: any,
-  ) {
-    super();
+    constructor(message: string, status: number, response: string, headers: { [key: string]: any; }, result: any) {
+        super();
 
-    this.message = message;
-    this.status = status;
-    this.response = response;
-    this.headers = headers;
-    this.result = result;
-  }
+        this.message = message;
+        this.status = status;
+        this.response = response;
+        this.headers = headers;
+        this.result = result;
+    }
 
-  protected isApiException = true;
+    protected isApiException = true;
 
-  static isApiException(obj: any): obj is ApiException {
-    return obj.isApiException === true;
-  }
+    static isApiException(obj: any): obj is ApiException {
+        return obj.isApiException === true;
+    }
 }
 
-function throwException(
-  message: string,
-  status: number,
-  response: string,
-  headers: { [key: string]: any },
-  result?: any,
-): any {
-  if (result !== null && result !== undefined) throw result;
-  else throw new ApiException(message, status, response, headers, null);
+function throwException(message: string, status: number, response: string, headers: { [key: string]: any; }, result?: any): any {
+    if (result !== null && result !== undefined)
+        throw result;
+    else
+        throw new ApiException(message, status, response, headers, null);
 }
 
 function isAxiosError(obj: any | undefined): obj is AxiosError {
-  return obj && obj.isAxiosError === true;
+    return obj && obj.isAxiosError === true;
 }
 
 //-----/Types.File-----
@@ -336,9 +936,10 @@ import { addResultTypeFactory } from './axios-client/helpers';
 export { setBaseUrl, getBaseUrl } from './axios-client/helpers';
 export { setAxiosFactory, getAxios } from './axios-client/helpers';
 
+
 //-----PersistorHydrator.File-----
 import type { PersistedClient } from '@tanstack/react-query-persist-client';
-import type { DehydratedState, QueryKey } from '@tanstack/react-query';
+import type { DehydratedState, QueryKey } from '@tanstack/react-query'
 import { getResultTypeFactory } from './axios-client/helpers';
 
 /*
@@ -348,23 +949,21 @@ import { getResultTypeFactory } from './axios-client/helpers';
 export function deserializeDate(str: unknown) {
   if (!str || typeof str !== 'string') return str;
   if (!/^\d\d\d\d\-\d\d\-\d\d/.test(str)) return str;
-
+  
   const date = new Date(str);
   const isDate = date instanceof Date && !isNaN(date as any);
-
+  
   return isDate ? date : str;
 }
 
 export function deserializeDatesInQueryKeys(queryKey: QueryKey) {
-  return (
-    queryKey
-      // We need to replace `null` with `undefined` in query key, because
-      // `undefined` is serialized as `null`.
-      // And most probably if we have `null` in QueryKey it actually means `undefined`.
-      // We can't keep nulls, because they have a different meaning, and e.g. boolean parameters are not allowed to be null.
-      .map((x) => (x === null ? undefined : x))
-      .map((x) => deserializeDate(x))
-  );
+  return queryKey
+    // We need to replace `null` with `undefined` in query key, because
+    // `undefined` is serialized as `null`.
+    // And most probably if we have `null` in QueryKey it actually means `undefined`.
+    // We can't keep nulls, because they have a different meaning, and e.g. boolean parameters are not allowed to be null.
+    .map(x => (x === null ? undefined : x))
+    .map(x => deserializeDate(x));
 }
 
 export function deserializeClassesInQueryData(queryKey: QueryKey, data: any) {
@@ -372,18 +971,11 @@ export function deserializeClassesInQueryData(queryKey: QueryKey, data: any) {
     return data;
   } else if (typeof data !== 'object') {
     return data;
-  } else if (
-    'pages' in data &&
-    'pageParams' in data &&
-    Array.isArray(data.pages) &&
-    Array.isArray(data.pageParams)
-  ) {
+  } else if ('pages' in data && 'pageParams' in data && Array.isArray(data.pages) && Array.isArray(data.pageParams)) {
     // infinite query
-    data.pages = data.pages.map((page: any) =>
-      deserializeClassesInQueryData(queryKey, page),
-    );
+    data.pages = data.pages.map((page:any) => deserializeClassesInQueryData(queryKey, page));
   } else if (Array.isArray(data)) {
-    return data.map((elem) => constructDtoClass(queryKey, elem));
+    return data.map(elem => constructDtoClass(queryKey, elem));
   } else {
     return constructDtoClass(queryKey, data);
   }
@@ -396,10 +988,7 @@ export function deserializeClassesInQueryData(queryKey: QueryKey, data: any) {
 export function persisterDeserialize(cache: string): PersistedClient {
   const client: PersistedClient = JSON.parse(cache);
   client.clientState.queries.forEach((query) => {
-    query.state.data = deserializeClassesInQueryData(
-      query.queryKey,
-      query.state.data,
-    );
+    query.state.data = deserializeClassesInQueryData(query.queryKey, query.state.data);
     query.queryKey = deserializeDatesInQueryKeys(query.queryKey);
   });
 
@@ -410,7 +999,8 @@ export function constructDtoClass(queryKey: QueryKey, data: any): unknown {
   const resultTypeKey = getResultTypeClassKey(queryKey);
   const constructorFunction = getResultTypeFactory(resultTypeKey);
 
-  if (!data || !constructorFunction) return data;
+  if (!data || !constructorFunction)
+    return data;
 
   return constructorFunction(data);
 }
@@ -429,5 +1019,11 @@ export function getResultTypeClassKey(queryKey: QueryKey): string {
   return queryKey.join('___');
 }
 
-export function initPersister() {}
+export function initPersister() {
+  
+  addResultTypeFactory('Client___teamsAll', (data: any) => { const result = new Anonymous(); result.init(data); return result; });
+  addResultTypeFactory('Client___meGET', (data: any) => { const result = new Anonymous3(); result.init(data); return result; });
+
+
+}
 //-----/PersistorHydrator.File----

--- a/src/api/axios-client/Query.ts
+++ b/src/api/axios-client/Query.ts
@@ -9,24 +9,8 @@
 // ReSharper disable InconsistentNaming
 import * as Types from '../axios-client';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import type {
-  UseQueryResult,
-  QueryFunctionContext,
-  UseQueryOptions,
-  QueryClient,
-  QueryKey,
-  MutationKey,
-  UseMutationOptions,
-  UseMutationResult,
-  QueryMeta,
-  MutationMeta,
-} from '@tanstack/react-query';
-import {
-  trimArrayEnd,
-  isParameterObject,
-  getBaseUrl,
-  addMetaToOptions,
-} from './helpers';
+import type { UseQueryResult, QueryFunctionContext, UseQueryOptions, QueryClient, QueryKey, MutationKey, UseMutationOptions, UseMutationResult, QueryMeta, MutationMeta } from '@tanstack/react-query';
+import { trimArrayEnd, isParameterObject, getBaseUrl, addMetaToOptions  } from './helpers';
 import type { QueryMetaContextValue } from 'react-query-swagger';
 import { QueryMetaContext } from 'react-query-swagger';
 import { useContext } from 'react';
@@ -40,49 +24,49 @@ export type CallbackQueryParameters = {
   code: string;
 };
 
+export type TeamsAllQueryParameters = {
+  offset: string | null | undefined;
+  limit: string | null | undefined;
+  search: string | null | undefined;
+};
+
+    
 export function anonymousUrl(): string {
-  let url_ = getBaseUrl() + '/';
-  url_ = url_.replace(/[?&]$/, '');
+  let url_ = getBaseUrl() + "/";
+  url_ = url_.replace(/[?&]$/, "");
   return url_;
 }
 
 let anonymousDefaultOptions: UseQueryOptions<void, unknown, void> = {
   queryFn: __anonymous,
 };
-export function getAnonymousDefaultOptions(): UseQueryOptions<
-  void,
-  unknown,
-  void
-> {
+export function getAnonymousDefaultOptions(): UseQueryOptions<void, unknown, void> {
   return anonymousDefaultOptions;
-}
-export function setAnonymousDefaultOptions(
-  options: UseQueryOptions<void, unknown, void>,
-) {
+};
+export function setAnonymousDefaultOptions(options: UseQueryOptions<void, unknown, void>) {
   anonymousDefaultOptions = options;
 }
 
 export function anonymousQueryKey(): QueryKey;
 export function anonymousQueryKey(...params: any[]): QueryKey {
-  return trimArrayEnd(['Client', 'anonymous']);
+  return trimArrayEnd([
+      'Client',
+      'anonymous',
+    ]);
 }
 function __anonymous() {
-  return Client().anonymous();
+  return Client().anonymous(
+    );
 }
 
 /**
  * @return Default Response
  */
-export function useAnonymousQuery<TSelectData = void, TError = unknown>(
-  options?: UseQueryOptions<void, TError, TSelectData>,
-  axiosConfig?: Partial<AxiosRequestConfig>,
-): UseQueryResult<TSelectData, TError>;
-export function useAnonymousQuery<TSelectData = void, TError = unknown>(
-  ...params: any[]
-): UseQueryResult<TSelectData, TError> {
-  let options: UseQueryOptions<void, TError, TSelectData> | undefined =
-    undefined;
-  let axiosConfig: AxiosRequestConfig | undefined;
+export function useAnonymousQuery<TSelectData = void, TError = unknown>(options?: UseQueryOptions<void, TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
+export function useAnonymousQuery<TSelectData = void, TError = unknown>(...params: any []): UseQueryResult<TSelectData, TError> {
+  let options: UseQueryOptions<void, TError, TSelectData> | undefined = undefined;
+  let axiosConfig: AxiosRequestConfig |undefined;
+  
 
   options = params[0] as any;
   axiosConfig = params[1] as any;
@@ -90,131 +74,37 @@ export function useAnonymousQuery<TSelectData = void, TError = unknown>(
   const metaContext = useContext(QueryMetaContext);
   options = addMetaToOptions(options, metaContext);
   if (axiosConfig) {
-    options = options ?? ({} as any);
+    options = options ?? { } as any;
     options!.meta = { ...options!.meta, axiosConfig };
   }
 
   return useQuery<void, TError, TSelectData>({
     queryFn: __anonymous,
     queryKey: anonymousQueryKey(),
-    ...(anonymousDefaultOptions as unknown as UseQueryOptions<
-      void,
-      TError,
-      TSelectData
-    >),
+    ...anonymousDefaultOptions as unknown as UseQueryOptions<void, TError, TSelectData>,
     ...options,
   });
 }
 /**
  * @return Default Response
  */
-export function setAnonymousData(
-  queryClient: QueryClient,
-  updater: (data: void | undefined) => void,
-) {
-  queryClient.setQueryData(anonymousQueryKey(), updater);
+export function setAnonymousData(queryClient: QueryClient, updater: (data: void | undefined) => void, ) {
+  queryClient.setQueryData(anonymousQueryKey(),
+    updater
+  );
 }
 
 /**
  * @return Default Response
  */
-export function setAnonymousDataByQueryId(
-  queryClient: QueryClient,
-  queryKey: QueryKey,
-  updater: (data: void | undefined) => void,
-) {
+export function setAnonymousDataByQueryId(queryClient: QueryClient, queryKey: QueryKey, updater: (data: void | undefined) => void) {
   queryClient.setQueryData(queryKey, updater);
 }
-
-export function meUrl(): string {
-  let url_ = getBaseUrl() + '/auth/me';
-  url_ = url_.replace(/[?&]$/, '');
-  return url_;
-}
-
-let meDefaultOptions: UseQueryOptions<void, unknown, void> = {
-  queryFn: __me,
-};
-export function getMeDefaultOptions(): UseQueryOptions<void, unknown, void> {
-  return meDefaultOptions;
-}
-export function setMeDefaultOptions(
-  options: UseQueryOptions<void, unknown, void>,
-) {
-  meDefaultOptions = options;
-}
-
-export function meQueryKey(): QueryKey;
-export function meQueryKey(...params: any[]): QueryKey {
-  const access_token = localStorage.getItem('access_token');
-  return trimArrayEnd(['Client', 'me', access_token]);
-}
-function __me() {
-  return Client().me();
-}
-
-/**
- * @return Default Response
- */
-export function useMeQuery<TSelectData = void, TError = unknown>(
-  options?: UseQueryOptions<void, TError, TSelectData>,
-  axiosConfig?: Partial<AxiosRequestConfig>,
-): UseQueryResult<TSelectData, TError>;
-export function useMeQuery<TSelectData = void, TError = unknown>(
-  ...params: any[]
-): UseQueryResult<TSelectData, TError> {
-  let options: UseQueryOptions<void, TError, TSelectData> | undefined =
-    undefined;
-  let axiosConfig: AxiosRequestConfig | undefined;
-
-  options = params[0] as any;
-  axiosConfig = params[1] as any;
-
-  const metaContext = useContext(QueryMetaContext);
-  options = addMetaToOptions(options, metaContext);
-  if (axiosConfig) {
-    options = options ?? ({} as any);
-    options!.meta = { ...options!.meta, axiosConfig };
-  }
-
-  return useQuery<void, TError, TSelectData>({
-    queryFn: __me,
-    queryKey: meQueryKey(),
-    staleTime: Infinity,
-    retry: false,
-
-    ...(meDefaultOptions as unknown as UseQueryOptions<
-      void,
-      TError,
-      TSelectData
-    >),
-    ...options,
-  });
-}
-/**
- * @return Default Response
- */
-export function setMeData(
-  queryClient: QueryClient,
-  updater: (data: void | undefined) => void,
-) {
-  queryClient.setQueryData(meQueryKey(), updater);
-}
-
-/**
- * @return Default Response
- */
-export function setMeDataByQueryId(
-  queryClient: QueryClient,
-  queryKey: QueryKey,
-  updater: (data: void | undefined) => void,
-) {
-  queryClient.setQueryData(queryKey, updater);
-}
-
+    
+    
 export function kakaoUrl(): string {
-  let url_ = getBaseUrl() + '/auth/kakao';
-  url_ = url_.replace(/[?&]$/, '');
+  let url_ = getBaseUrl() + "/auth/kakao";
+  url_ = url_.replace(/[?&]$/, "");
   return url_;
 }
 
@@ -223,34 +113,31 @@ let kakaoDefaultOptions: UseQueryOptions<void, unknown, void> = {
 };
 export function getKakaoDefaultOptions(): UseQueryOptions<void, unknown, void> {
   return kakaoDefaultOptions;
-}
-export function setKakaoDefaultOptions(
-  options: UseQueryOptions<void, unknown, void>,
-) {
+};
+export function setKakaoDefaultOptions(options: UseQueryOptions<void, unknown, void>) {
   kakaoDefaultOptions = options;
 }
 
 export function kakaoQueryKey(): QueryKey;
 export function kakaoQueryKey(...params: any[]): QueryKey {
-  return trimArrayEnd(['Client', 'kakao']);
+  return trimArrayEnd([
+      'Client',
+      'kakao',
+    ]);
 }
 function __kakao() {
-  return Client().kakao();
+  return Client().kakao(
+    );
 }
 
 /**
  * @return Default Response
  */
-export function useKakaoQuery<TSelectData = void, TError = unknown>(
-  options?: UseQueryOptions<void, TError, TSelectData>,
-  axiosConfig?: Partial<AxiosRequestConfig>,
-): UseQueryResult<TSelectData, TError>;
-export function useKakaoQuery<TSelectData = void, TError = unknown>(
-  ...params: any[]
-): UseQueryResult<TSelectData, TError> {
-  let options: UseQueryOptions<void, TError, TSelectData> | undefined =
-    undefined;
-  let axiosConfig: AxiosRequestConfig | undefined;
+export function useKakaoQuery<TSelectData = void, TError = unknown>(options?: UseQueryOptions<void, TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
+export function useKakaoQuery<TSelectData = void, TError = unknown>(...params: any []): UseQueryResult<TSelectData, TError> {
+  let options: UseQueryOptions<void, TError, TSelectData> | undefined = undefined;
+  let axiosConfig: AxiosRequestConfig |undefined;
+  
 
   options = params[0] as any;
   axiosConfig = params[1] as any;
@@ -258,106 +145,91 @@ export function useKakaoQuery<TSelectData = void, TError = unknown>(
   const metaContext = useContext(QueryMetaContext);
   options = addMetaToOptions(options, metaContext);
   if (axiosConfig) {
-    options = options ?? ({} as any);
+    options = options ?? { } as any;
     options!.meta = { ...options!.meta, axiosConfig };
   }
 
   return useQuery<void, TError, TSelectData>({
     queryFn: __kakao,
     queryKey: kakaoQueryKey(),
-    ...(kakaoDefaultOptions as unknown as UseQueryOptions<
-      void,
-      TError,
-      TSelectData
-    >),
+    ...kakaoDefaultOptions as unknown as UseQueryOptions<void, TError, TSelectData>,
     ...options,
   });
 }
 /**
  * @return Default Response
  */
-export function setKakaoData(
-  queryClient: QueryClient,
-  updater: (data: void | undefined) => void,
-) {
-  queryClient.setQueryData(kakaoQueryKey(), updater);
+export function setKakaoData(queryClient: QueryClient, updater: (data: void | undefined) => void, ) {
+  queryClient.setQueryData(kakaoQueryKey(),
+    updater
+  );
 }
 
 /**
  * @return Default Response
  */
-export function setKakaoDataByQueryId(
-  queryClient: QueryClient,
-  queryKey: QueryKey,
-  updater: (data: void | undefined) => void,
-) {
+export function setKakaoDataByQueryId(queryClient: QueryClient, queryKey: QueryKey, updater: (data: void | undefined) => void) {
   queryClient.setQueryData(queryKey, updater);
 }
-
+    
+    
 export function callbackUrl(code: string): string {
-  let url_ = getBaseUrl() + '/auth/kakao/callback?';
+  let url_ = getBaseUrl() + "/auth/kakao/callback?";
   if (code === undefined || code === null)
     throw new Error("The parameter 'code' must be defined and cannot be null.");
-  else url_ += 'code=' + encodeURIComponent('' + code) + '&';
-  url_ = url_.replace(/[?&]$/, '');
+  else
+    url_ += "code=" + encodeURIComponent("" + code) + "&";
+  url_ = url_.replace(/[?&]$/, "");
   return url_;
 }
 
 let callbackDefaultOptions: UseQueryOptions<void, unknown, void> = {
   queryFn: __callback,
 };
-export function getCallbackDefaultOptions(): UseQueryOptions<
-  void,
-  unknown,
-  void
-> {
+export function getCallbackDefaultOptions(): UseQueryOptions<void, unknown, void> {
   return callbackDefaultOptions;
-}
-export function setCallbackDefaultOptions(
-  options: UseQueryOptions<void, unknown, void>,
-) {
+};
+export function setCallbackDefaultOptions(options: UseQueryOptions<void, unknown, void>) {
   callbackDefaultOptions = options;
 }
 
 export function callbackQueryKey(code: string): QueryKey;
 export function callbackQueryKey(...params: any[]): QueryKey {
   if (params.length === 1 && isParameterObject(params[0])) {
-    const { code } = params[0] as CallbackQueryParameters;
+    const { code,  } = params[0] as CallbackQueryParameters;
 
-    return trimArrayEnd(['Client', 'callback', code as any]);
+    return trimArrayEnd([
+        'Client',
+        'callback',
+        code as any,
+      ]);
   } else {
-    return trimArrayEnd(['Client', 'callback', ...params]);
+    return trimArrayEnd([
+        'Client',
+        'callback',
+        ...params
+      ]);
   }
 }
 function __callback(context: QueryFunctionContext) {
-  return Client().callback(context.queryKey[2] as string);
+  return Client().callback(
+      context.queryKey[2] as string    );
 }
 
-export function useCallbackQuery<TSelectData = void, TError = unknown>(
-  dto: CallbackQueryParameters,
-  options?: UseQueryOptions<void, TError, TSelectData>,
-  axiosConfig?: Partial<AxiosRequestConfig>,
-): UseQueryResult<TSelectData, TError>;
+export function useCallbackQuery<TSelectData = void, TError = unknown>(dto: CallbackQueryParameters, options?: UseQueryOptions<void, TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
 /**
  * @return Default Response
  * @deprecated
  */
-export function useCallbackQuery<TSelectData = void, TError = unknown>(
-  code: string,
-  options?: UseQueryOptions<void, TError, TSelectData>,
-  axiosConfig?: Partial<AxiosRequestConfig>,
-): UseQueryResult<TSelectData, TError>;
-export function useCallbackQuery<TSelectData = void, TError = unknown>(
-  ...params: any[]
-): UseQueryResult<TSelectData, TError> {
-  let options: UseQueryOptions<void, TError, TSelectData> | undefined =
-    undefined;
-  let axiosConfig: AxiosRequestConfig | undefined;
+export function useCallbackQuery<TSelectData = void, TError = unknown>(code: string, options?: UseQueryOptions<void, TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
+export function useCallbackQuery<TSelectData = void, TError = unknown>(...params: any []): UseQueryResult<TSelectData, TError> {
+  let options: UseQueryOptions<void, TError, TSelectData> | undefined = undefined;
+  let axiosConfig: AxiosRequestConfig |undefined;
   let code: any = undefined;
-
+  
   if (params.length > 0) {
     if (isParameterObject(params[0])) {
-      ({ code } = params[0] as CallbackQueryParameters);
+      ({ code,  } = params[0] as CallbackQueryParameters);
       options = params[1];
       axiosConfig = params[2];
     } else {
@@ -368,18 +240,14 @@ export function useCallbackQuery<TSelectData = void, TError = unknown>(
   const metaContext = useContext(QueryMetaContext);
   options = addMetaToOptions(options, metaContext);
   if (axiosConfig) {
-    options = options ?? ({} as any);
+    options = options ?? { } as any;
     options!.meta = { ...options!.meta, axiosConfig };
   }
 
   return useQuery<void, TError, TSelectData>({
     queryFn: __callback,
     queryKey: callbackQueryKey(code),
-    ...(callbackDefaultOptions as unknown as UseQueryOptions<
-      void,
-      TError,
-      TSelectData
-    >),
+    ...callbackDefaultOptions as unknown as UseQueryOptions<void, TError, TSelectData>,
     ...options,
   });
 }
@@ -387,22 +255,251 @@ export function useCallbackQuery<TSelectData = void, TError = unknown>(
  * @return Default Response
  * @deprecated
  */
-export function setCallbackData(
-  queryClient: QueryClient,
-  updater: (data: void | undefined) => void,
-  code: string,
-) {
-  queryClient.setQueryData(callbackQueryKey(code), updater);
+export function setCallbackData(queryClient: QueryClient, updater: (data: void | undefined) => void, code: string) {
+  queryClient.setQueryData(callbackQueryKey(code),
+    updater
+  );
 }
 
 /**
  * @return Default Response
  * @deprecated
  */
-export function setCallbackDataByQueryId(
-  queryClient: QueryClient,
-  queryKey: QueryKey,
-  updater: (data: void | undefined) => void,
-) {
+export function setCallbackDataByQueryId(queryClient: QueryClient, queryKey: QueryKey, updater: (data: void | undefined) => void) {
   queryClient.setQueryData(queryKey, updater);
+}
+    
+    
+export function teamsAllUrl(offset: string | null | undefined, limit: string | null | undefined, search: string | null | undefined): string {
+  let url_ = getBaseUrl() + "/teams?";
+if (offset !== undefined && offset !== null)
+    url_ += "offset=" + encodeURIComponent("" + offset) + "&";
+if (limit !== undefined && limit !== null)
+    url_ += "limit=" + encodeURIComponent("" + limit) + "&";
+if (search !== undefined && search !== null)
+    url_ += "search=" + encodeURIComponent("" + search) + "&";
+  url_ = url_.replace(/[?&]$/, "");
+  return url_;
+}
+
+let teamsAllDefaultOptions: UseQueryOptions<Types.Anonymous[], unknown, Types.Anonymous[]> = {
+  queryFn: __teamsAll,
+};
+export function getTeamsAllDefaultOptions(): UseQueryOptions<Types.Anonymous[], unknown, Types.Anonymous[]> {
+  return teamsAllDefaultOptions;
+};
+export function setTeamsAllDefaultOptions(options: UseQueryOptions<Types.Anonymous[], unknown, Types.Anonymous[]>) {
+  teamsAllDefaultOptions = options;
+}
+
+export function teamsAllQueryKey(dto: TeamsAllQueryParameters): QueryKey;
+export function teamsAllQueryKey(offset: string | null | undefined, limit: string | null | undefined, search: string | null | undefined): QueryKey;
+export function teamsAllQueryKey(...params: any[]): QueryKey {
+  if (params.length === 1 && isParameterObject(params[0])) {
+    const { offset, limit, search,  } = params[0] as TeamsAllQueryParameters;
+
+    return trimArrayEnd([
+        'Client',
+        'teamsAll',
+        offset as any,
+        limit as any,
+        search as any,
+      ]);
+  } else {
+    return trimArrayEnd([
+        'Client',
+        'teamsAll',
+        ...params
+      ]);
+  }
+}
+function __teamsAll(context: QueryFunctionContext) {
+  return Client().teamsAll(
+      context.queryKey[2] as string | null | undefined,       context.queryKey[3] as string | null | undefined,       context.queryKey[4] as string | null | undefined    );
+}
+
+export function useTeamsAllQuery<TSelectData = Types.Anonymous[], TError = unknown>(dto: TeamsAllQueryParameters, options?: UseQueryOptions<Types.Anonymous[], TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
+/**
+ * @param offset (optional) number
+ * @param limit (optional) number
+ * @param search (optional) 검색어
+ * @return Default Response
+ */
+export function useTeamsAllQuery<TSelectData = Types.Anonymous[], TError = unknown>(offset: string | null | undefined, limit: string | null | undefined, search: string | null | undefined, options?: UseQueryOptions<Types.Anonymous[], TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
+export function useTeamsAllQuery<TSelectData = Types.Anonymous[], TError = unknown>(...params: any []): UseQueryResult<TSelectData, TError> {
+  let options: UseQueryOptions<Types.Anonymous[], TError, TSelectData> | undefined = undefined;
+  let axiosConfig: AxiosRequestConfig |undefined;
+  let offset: any = undefined;
+  let limit: any = undefined;
+  let search: any = undefined;
+  
+  if (params.length > 0) {
+    if (isParameterObject(params[0])) {
+      ({ offset, limit, search,  } = params[0] as TeamsAllQueryParameters);
+      options = params[1];
+      axiosConfig = params[2];
+    } else {
+      [offset, limit, search, options, axiosConfig] = params;
+    }
+  }
+
+  const metaContext = useContext(QueryMetaContext);
+  options = addMetaToOptions(options, metaContext);
+  if (axiosConfig) {
+    options = options ?? { } as any;
+    options!.meta = { ...options!.meta, axiosConfig };
+  }
+
+  return useQuery<Types.Anonymous[], TError, TSelectData>({
+    queryFn: __teamsAll,
+    queryKey: teamsAllQueryKey(offset, limit, search),
+    ...teamsAllDefaultOptions as unknown as UseQueryOptions<Types.Anonymous[], TError, TSelectData>,
+    ...options,
+  });
+}
+/**
+ * @param offset (optional) number
+ * @param limit (optional) number
+ * @param search (optional) 검색어
+ * @return Default Response
+ */
+export function setTeamsAllData(queryClient: QueryClient, updater: (data: Types.Anonymous[] | undefined) => Types.Anonymous[], offset: string | null | undefined, limit: string | null | undefined, search: string | null | undefined) {
+  queryClient.setQueryData(teamsAllQueryKey(offset, limit, search),
+    updater
+  );
+}
+
+/**
+ * @param offset (optional) number
+ * @param limit (optional) number
+ * @param search (optional) 검색어
+ * @return Default Response
+ */
+export function setTeamsAllDataByQueryId(queryClient: QueryClient, queryKey: QueryKey, updater: (data: Types.Anonymous[] | undefined) => Types.Anonymous[]) {
+  queryClient.setQueryData(queryKey, updater);
+}
+    
+    
+export function teamsUrl(): string {
+  let url_ = getBaseUrl() + "/teams";
+  url_ = url_.replace(/[?&]$/, "");
+  return url_;
+}
+
+export function teamsMutationKey(): MutationKey {
+  return trimArrayEnd([
+      'Client',
+      'teams',
+    ]);
+}
+
+/**
+ * @param body (optional) 
+ * @return Default Response
+ */
+export function useTeamsMutation<TContext>(options?: Omit<UseMutationOptions<Types.Anonymous2, unknown, Types.Body, TContext>, 'mutationKey' | 'mutationFn'>): UseMutationResult<Types.Anonymous2, unknown, Types.Body, TContext> {
+  const key = teamsMutationKey();
+  
+  const metaContext = useContext(QueryMetaContext);
+  options = addMetaToOptions(options, metaContext);
+  
+      return useMutation((body: Types.Body) => Client().teams(body), {...options, mutationKey: key});
+}
+  
+    
+export function meGETUrl(): string {
+  let url_ = getBaseUrl() + "/users/me";
+  url_ = url_.replace(/[?&]$/, "");
+  return url_;
+}
+
+let meGETDefaultOptions: UseQueryOptions<Types.Anonymous3, unknown, Types.Anonymous3> = {
+  queryFn: __meGET,
+};
+export function getMeGETDefaultOptions(): UseQueryOptions<Types.Anonymous3, unknown, Types.Anonymous3> {
+  return meGETDefaultOptions;
+};
+export function setMeGETDefaultOptions(options: UseQueryOptions<Types.Anonymous3, unknown, Types.Anonymous3>) {
+  meGETDefaultOptions = options;
+}
+
+export function meGETQueryKey(): QueryKey;
+export function meGETQueryKey(...params: any[]): QueryKey {
+  return trimArrayEnd([
+      'Client',
+      'meGET',
+    ]);
+}
+function __meGET() {
+  return Client().meGET(
+    );
+}
+
+/**
+ * @return Default Response
+ */
+export function useMeGETQuery<TSelectData = Types.Anonymous3, TError = unknown>(options?: UseQueryOptions<Types.Anonymous3, TError, TSelectData>, axiosConfig?: Partial<AxiosRequestConfig>): UseQueryResult<TSelectData, TError>;
+export function useMeGETQuery<TSelectData = Types.Anonymous3, TError = unknown>(...params: any []): UseQueryResult<TSelectData, TError> {
+  let options: UseQueryOptions<Types.Anonymous3, TError, TSelectData> | undefined = undefined;
+  let axiosConfig: AxiosRequestConfig |undefined;
+  
+
+  options = params[0] as any;
+  axiosConfig = params[1] as any;
+
+  const metaContext = useContext(QueryMetaContext);
+  options = addMetaToOptions(options, metaContext);
+  if (axiosConfig) {
+    options = options ?? { } as any;
+    options!.meta = { ...options!.meta, axiosConfig };
+  }
+
+  return useQuery<Types.Anonymous3, TError, TSelectData>({
+    queryFn: __meGET,
+    queryKey: meGETQueryKey(),
+    ...meGETDefaultOptions as unknown as UseQueryOptions<Types.Anonymous3, TError, TSelectData>,
+    ...options,
+  });
+}
+/**
+ * @return Default Response
+ */
+export function setMeGETData(queryClient: QueryClient, updater: (data: Types.Anonymous3 | undefined) => Types.Anonymous3, ) {
+  queryClient.setQueryData(meGETQueryKey(),
+    updater
+  );
+}
+
+/**
+ * @return Default Response
+ */
+export function setMeGETDataByQueryId(queryClient: QueryClient, queryKey: QueryKey, updater: (data: Types.Anonymous3 | undefined) => Types.Anonymous3) {
+  queryClient.setQueryData(queryKey, updater);
+}
+    
+    
+export function mePUTUrl(): string {
+  let url_ = getBaseUrl() + "/users/me";
+  url_ = url_.replace(/[?&]$/, "");
+  return url_;
+}
+
+export function mePUTMutationKey(): MutationKey {
+  return trimArrayEnd([
+      'Client',
+      'mePUT',
+    ]);
+}
+
+/**
+ * @param body (optional) 
+ * @return Default Response
+ */
+export function useMePUTMutation<TContext>(options?: Omit<UseMutationOptions<Types.Anonymous4, unknown, Types.Body2, TContext>, 'mutationKey' | 'mutationFn'>): UseMutationResult<Types.Anonymous4, unknown, Types.Body2, TContext> {
+  const key = mePUTMutationKey();
+  
+  const metaContext = useContext(QueryMetaContext);
+  options = addMetaToOptions(options, metaContext);
+  
+      return useMutation((body: Types.Body2) => Client().mePUT(body), {...options, mutationKey: key});
 }

--- a/src/api/axios-client/helpers.ts
+++ b/src/api/axios-client/helpers.ts
@@ -2,7 +2,6 @@
 
 import type { QueryMeta, MutationMeta } from '@tanstack/react-query';
 import type { QueryMetaContextValue } from 'react-query-swagger';
-
 import axios from 'axios';
 import type { AxiosInstance } from 'axios';
 

--- a/src/components/common/Drawer.tsx
+++ b/src/components/common/Drawer.tsx
@@ -5,7 +5,7 @@ import logoImage from 'assets/logo.png';
 import { Link, useLocation } from 'react-router-dom';
 import { AiOutlineClose } from 'react-icons/ai';
 
-import { useMeQuery } from 'api/axios-client/Query';
+import { useMeGETQuery } from 'api/axios-client/Query';
 
 interface Props {
   open: boolean;
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const Drawer = ({ open, closeDrawer }: Props) => {
-  const { data: user } = useMeQuery();
+  const { data: user } = useMeGETQuery();
 
   const logout = () => {
     localStorage.removeItem('access_token');

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,17 +9,19 @@ import { RxHamburgerMenu } from 'react-icons/rx';
 import { BiBell } from 'react-icons/bi';
 
 import Drawer from './Drawer';
-import { useMeQuery } from 'api/axios-client/Query';
+import { useMeGETQuery } from 'api/axios-client/Query';
 import { Button, Input, Popover } from 'antd';
 import { User } from 'types/common';
 const { Search } = Input;
 
 const Header = () => {
   const location = useLocation();
-  const { data: user } = useMeQuery() as {
+  const { data: user } = useMeGETQuery({
+    staleTime: Infinity,
+  }) as {
     data: User;
   };
-  console.log(blue);
+
   const [open, setOpen] = useState(false);
   const [popOverOpen, setPopOverOpen] = useState(false);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { initPersister, setBaseUrl } from 'api/axios-client';
+import { initPersister, setAxiosFactory } from 'api/axios-client';
+import { setMeGETDefaultOptions } from 'api/axios-client/Query';
+import axios from 'axios';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ThemeProvider } from 'styled-components';
@@ -11,7 +13,26 @@ import { theme } from './styles/theme';
 const queryClient = new QueryClient();
 initPersister();
 
-setBaseUrl('http://rasp.jaejun.me:8000');
+setAxiosFactory(() => {
+  const access_token = localStorage.getItem('access_token');
+  const instance = axios.create({
+    baseURL: 'http://rasp.jaejun.me:8000',
+    timeout: 1000,
+    headers: {
+      'X-Custom-Header': 'foobar',
+      Authorization: access_token ? `Bearer ${access_token}` : '',
+    },
+  });
+
+  return instance;
+});
+
+setMeGETDefaultOptions({
+  staleTime: Infinity,
+  retry: false,
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,


### PR DESCRIPTION
# What is this PR? 🔍

- 서비스 스펙 : 전체

# Changes 📝

- swagger ui 의 업데이트로 `npx react-query-swagger /tanstack /input:http://rasp.jaejun.me:8000/docs/json /output:src/api/axios-client.ts /template:Axios` 해당 커맨드를 다시 실행하여 파일을 만들었습니다.
- react-query-swqgger 에서 제공하는 함수를 이용하여 기본적인 axios , query 옵션을 수정하였습니다.


# Test Checklist ☑️

- [ ] 로그인, 로그아웃


# ETC 📎

이전에 react-query-swqgger 에 대해 잘알아보지 않고 작업을 해서
위의 커맨드로 만들어진 결과 파일인 src/api 아래 파일들을 직접 수정했었는데 다시 알아보니 설정을 할 수 있는 함수가 있어 그에 맞게 수정하였습니다.

참고 문서: https://www.npmjs.com/package/react-query-swagger